### PR TITLE
2 of 13 test fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
+  - 8

--- a/index.js
+++ b/index.js
@@ -1,46 +1,51 @@
 // Load modules
 
-const Boom = require('boom');
-const Hoek = require('hoek');
-const _ = require('lodash');
+const Boom = require("boom");
+const Hoek = require("hoek");
+const _ = require("lodash");
 
 // Declare internals
 
 let internals = {};
-internals.pluginName = 'hapiRouteAcl';
+internals.pluginName = "hapiRouteAcl";
 
-exports.plugin = {  
+exports.plugin = {
   register: (server, options) => {
     if (_.isUndefined(options.permissionsFunc)) {
-      throw new Error('options.permissionsFunc is required');
+      throw new Error("options.permissionsFunc is required");
     } else if (!_.isFunction(options.permissionsFunc)) {
-      throw new Error('options.permissionsFunc must be a valid function');
+      throw new Error("options.permissionsFunc must be a valid function");
     } else {
       internals.permissionsFunc = options.permissionsFunc;
-      server.ext({type:'onPostAuth', method: internals.implementation});
+      server.ext({ type: "onPostAuth", method: internals.implementation });
     }
   },
-  pkg: require('./package.json')
-}
+  pkg: require("./package.json")
+};
 
 internals.implementation = function(request, h) {
   if (!_.isEmpty(request.route.settings.plugins[internals.pluginName])) {
-    let requiredPermissions = request.route.settings.plugins[internals.pluginName].permissions;
+    let requiredPermissions =
+      request.route.settings.plugins[internals.pluginName].permissions;
     if (!_.isEmpty(requiredPermissions)) {
-      internals.permissionsFunc(request.auth.credentials, function(error, userPermissions) {
-        let hasPermission = internals.checkPermissions(requiredPermissions, userPermissions);
+      internals.permissionsFunc(request.auth.credentials, function(
+        error,
+        userPermissions
+      ) {
+        let hasPermission = internals.checkPermissions(
+          requiredPermissions,
+          userPermissions
+        );
         if (hasPermission) {
-          return h.continue();
+          return h.continue;
         } else {
-          throw Boom.unauthorized('Access denied');
+          throw Boom.unauthorized("Access denied");
         }
       });
-    } else {
-      return h.continue();
     }
-  } else {
-    return h.continue();
+    return h.continue;
   }
+  return h.continue;
 };
 
 internals.checkPermissions = function(requiredPermissions, userPermissions) {
@@ -51,16 +56,22 @@ internals.checkPermissions = function(requiredPermissions, userPermissions) {
   let permissionMap = {};
 
   _.forEach(requiredPermissions, function(requiredPermission) {
-    Hoek.assert(_.isString(requiredPermission), 'permission must be a string');
+    Hoek.assert(_.isString(requiredPermission), "permission must be a string");
 
-    let parts = requiredPermission.split(':');
+    let parts = requiredPermission.split(":");
 
-    Hoek.assert(parts.length === 2, 'permission must be formatted: [routeName]:[read|create|edit|delete]');
+    Hoek.assert(
+      parts.length === 2,
+      "permission must be formatted: [routeName]:[read|create|edit|delete]"
+    );
 
     let routeName = parts[0];
     let crud = parts[1];
 
-    if (_.isUndefined(userPermissions[routeName]) || _.isUndefined(userPermissions[routeName][crud])) {
+    if (
+      _.isUndefined(userPermissions[routeName]) ||
+      _.isUndefined(userPermissions[routeName][crud])
+    ) {
       permissionMap[requiredPermission] = false;
     } else {
       permissionMap[requiredPermission] = userPermissions[routeName][crud];

--- a/package.json
+++ b/package.json
@@ -29,15 +29,14 @@
     "lodash": ""
   },
   "peerDependencies": {
-    "hapi": ">=8.x.x"
+    "hapi": ">=17.x.x"
   },
   "devDependencies": {
-    "code": "^1.3.0",
-    "hapi": "^8.3.1",
+    "code": "",
     "hapi": "",
-    "lab": "^5.5.0"
+    "lab": ""
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=8"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,10 @@
-'use strict';
+"use strict";
 
 // Load modules
 
-var Code = require('code');
-var Lab = require('lab');
-var Hapi = require('hapi');
+var Code = require("code");
+var Lab = require("lab");
+var Hapi = require("hapi");
 
 // Declare internals
 
@@ -37,7 +37,7 @@ internals.permissionsFunc = function(credentials, callback) {
 
 // Test shortcuts
 
-var lab = exports.lab = Lab.script();
+var lab = (exports.lab = Lab.script());
 var before = lab.before;
 var beforeEach = lab.beforeEach;
 var after = lab.after;
@@ -45,85 +45,80 @@ var describe = lab.describe;
 var it = lab.it;
 var expect = Code.expect;
 
-describe('hapi-route-acl', function() {
-
-  describe('registration', function() {
+describe("hapi-route-acl", () => {
+  describe("registration", () => {
     var server;
 
-    beforeEach(function(done) {
+    beforeEach(() => {
       server = new Hapi.Server();
-      server.connection();
-      done();
+      server.start();
     });
 
-    it('should return an error if options.permissionsFunc is not defined', function(done) {
-      server.register({
-        register: require('./../')
-      }, function(err) {
+    it("should return an error if options.permissionsFunc is not defined", async () => {
+      try {
+        await server.register({
+          plugin: require("./../")
+        });
+      } catch (err) {
         expect(err).to.exist();
-        done();
-      });
+      }
     });
 
-    it('should return an error if options.permissionsFunc is not a function', function(done) {
-      server.register({
-        register: require('./../'),
-        options: {
-          permissionsFunc: 123
-        }
-      }, function(err) {
+    it("should return an error if options.permissionsFunc is not a function", async () => {
+      try {
+        await server.register({
+          plugin: require("./../"),
+          options: {
+            permissionsFunc: 123
+          }
+        });
+      } catch (err) {
         expect(err).to.exist();
-        done();
-      });
+      }
     });
-
   });
 
-  describe('route protection', function() {
+  describe("route protection", function() {
     var server;
 
-    beforeEach(function(done) {
+    beforeEach(() => {
       server = new Hapi.Server();
-      server.connection();
-      server.register({
-        register: require('./../'),
-        options: {
-          permissionsFunc: internals.permissionsFunc
-        }
-      }, function(err) {
-        if (err) {
-          throw err;
-        }
-      });
-      done();
+      server
+        .register({
+          plugin: require("./../"),
+          options: {
+            permissionsFunc: internals.permissionsFunc
+          }
+        })
+        .then(() => {
+          server.start();
+        });
     });
 
-    it('should allow access to a route if plugin configuration is not defined in route config', function(done) {
+    it("should allow access to a route if plugin configuration is not defined in route config", async () => {
       server.route({
-        method: 'GET',
-        path: '/unprotected1',
+        method: "GET",
+        path: "/unprotected1",
         config: {
-          handler: function(request, reply) {
-            reply('hola mi amigo');
+          handler: function(request, h) {
+            return "hola mi amigo";
           }
         }
       });
-      server.inject({
-        method: 'GET',
-        url: '/unprotected1'
-      }, function(res) {
-        expect(res.statusCode).to.equal(200);
-        done();
+      let res = await server.inject({
+        method: "GET",
+        url: "/unprotected1"
       });
+      expect(res.statusCode).to.equal(200);
     });
 
-    it('should allow access to a route if required permission array is empty', function(done) {
+    it("should allow access to a route if required permission array is empty", async () => {
       server.route({
-        method: 'GET',
-        path: '/unprotected2',
+        method: "GET",
+        path: "/unprotected2",
         config: {
-          handler: function(request, reply) {
-            reply('como estas?');
+          handler: function(request, h) {
+            return "como estas?";
           },
           plugins: {
             hapiRouteAcl: {
@@ -132,102 +127,99 @@ describe('hapi-route-acl', function() {
           }
         }
       });
-      server.inject({
-        method: 'GET',
-        url: '/unprotected2'
-      }, function(res) {
-        expect(res.statusCode).to.equal(200);
-        done();
+      let res = await server.inject({
+        method: "GET",
+        url: "/unprotected2"
       });
+      expect(res.statusCode).to.equal(200);
     });
 
-    it('should allow access to a route if user has permission', function(done) {
+    it("should allow access to a route if user has permission", async () => {
       server.route({
-        method: 'GET',
-        path: '/cars',
+        method: "GET",
+        path: "/cars",
         config: {
-          handler: function(request, reply) {
-            reply(['Toyota Camry', 'Honda Accord', 'Ford Fusion']);
+          handler: function(request, h) {
+            return ["Toyota Camry", "Honda Accord", "Ford Fusion"];
           },
           plugins: {
             hapiRouteAcl: {
-              permissions: ['cars:read']
+              permissions: ["cars:read"]
             }
           }
         }
       });
-      server.inject({
-        method: 'GET',
-        url: '/cars'
-      }, function(res) {
-        expect(res.statusCode).to.equal(200);
-        done();
+      let res = await server.inject({
+        method: "GET",
+        url: "/cars"
       });
+      expect(res.statusCode).to.equal(200);
     });
 
-    it('should allow access for permissions defined as a string', function(done) {
+    it("should allow access for permissions defined as a string", async () => {
       server.route({
-        method: 'GET',
-        path: '/cars/{id}',
+        method: "GET",
+        path: "/cars/{id}",
         config: {
-          handler: function(request, reply) {
-            reply('Toyota Camry');
+          handler: function(request, h) {
+            return "Toyota Camry";
           },
           plugins: {
             hapiRouteAcl: {
-              permissions: 'cars:read'
+              permissions: "cars:read"
             }
           }
         }
       });
-      server.inject({
-        method: 'GET',
-        url: '/cars/1'
-      }, function(res) {
-        expect(res.statusCode).to.equal(200);
-        done();
+      let res = await server.inject({
+        method: "GET",
+        url: "/cars/1"
       });
+      expect(res.statusCode).to.equal(200);
     });
 
-    it('should deny access to a route if user does not have permission', function(done) {
+    it("should deny access to a route if user does not have permission", async () => {
       server.route({
-        method: 'POST',
-        path: '/cars',
+        method: "POST",
+        path: "/cars",
         config: {
-          handler: function(request, reply) {
-            reply('car created!');
+          handler: function(request, h) {
+            return "car created!";
           },
           plugins: {
             hapiRouteAcl: {
-              permissions: ['cars:create']
+              permissions: ["cars:create"]
             }
           }
         }
       });
-      server.inject({
-        method: 'POST',
-        url: '/cars'
-      }, function(res) {
-        expect(res.statusCode).to.equal(401);
-        done();
+      let res = await server.inject({
+        method: "POST",
+        url: "/cars"
       });
+      expect(res.statusCode).to.equal(401);
     });
 
-    it('should throw an exception if route permission is not a string', function(done) {
-      server.ext('onPostAuth', function (request, reply) {
-        request.domain.on('error', function (error) {
-          request.caughtError = error;
-        });
-
-        return reply.continue();
-      }, { before: ['hapi-route-acl'] });
+    it("should throw an exception if route permission is not a string", async () => {
+      server.ext(
+        "onPostAuth",
+        function(request, h) {
+          request.domain.on("error", function(error) {
+            request.caughtError = error;
+          });
+          return h.continue;
+        },
+        {
+          before: ["hapi-route-acl"]
+        }
+      );
 
       server.route({
-        method: 'GET',
-        path: '/cars',
+        method: "GET",
+        path: "/cars",
         config: {
-          handler: function(request, reply) {
-            reply(['Toyota Camry', 'Honda Accord', 'Ford Fusion']);
+          handler: function(request, h) {
+            ["Toyota Camry", "Honda Accord", "Ford Fusion"];
           },
           plugins: {
             hapiRouteAcl: {
@@ -237,150 +229,143 @@ describe('hapi-route-acl', function() {
         }
       });
 
-      server.inject({
-        method: 'GET',
-        url: '/cars'
-      }, function(res) {
-        var error = res.request.caughtError;
-
-        expect(error).to.be.an.instanceof(Error);
-        expect(error.message).to.equal('Uncaught error: permission must be a string');
-        done();
+      let res = await server.inject({
+        method: "GET",
+        url: "/cars"
       });
+      var error = res.request.caughtError;
+
+      expect(error).to.be.an.instanceof(Error);
+      expect(error.message).to.equal(
+        "Uncaught error: permission must be a string"
+      );
     });
 
-    it('should throw an exception if route permission is not formatted properly', function(done) {
-      server.ext('onPostAuth', function (request, reply) {
-        request.domain.on('error', function (error) {
-          request.caughtError = error;
-        });
+    it("should throw an exception if route permission is not formatted properly", async () => {
+      server.ext(
+        "onPostAuth",
+        function(request, reply) {
+          request.domain.on("error", function(error) {
+            request.caughtError = error;
+          });
 
-        return reply.continue();
-      }, { before: ['hapi-route-acl'] });
+          return reply.continue;
+        },
+        { before: ["hapi-route-acl"] }
+      );
 
       server.route({
-        method: 'GET',
-        path: '/cars',
+        method: "GET",
+        path: "/cars",
         config: {
           handler: function(request, reply) {
-            reply(['Toyota Camry', 'Honda Accord', 'Ford Fusion']);
+            reply(["Toyota Camry", "Honda Accord", "Ford Fusion"]);
           },
           plugins: {
             hapiRouteAcl: {
-              permissions: ['carsread'] // missing colon
+              permissions: ["carsread"] // missing colon
             }
           }
         }
       });
 
-      server.inject({
-        method: 'GET',
-        url: '/cars'
-      }, function(res) {
-        var error = res.request.caughtError;
-
-        expect(error).to.be.an.instanceof(Error);
-        expect(error.message).to.equal('Uncaught error: permission must be formatted: [routeName]:[read|create|edit|delete]');
-        done();
+      let res = await server.inject({
+        method: "GET",
+        url: "/cars"
       });
+      var error = res.request.caughtError;
+      expect(error).to.be.an.instanceof(Error);
+      expect(error.message).to.equal(
+        "Uncaught error: permission must be formatted: [routeName]:[read|create|edit|delete]"
+      );
     });
 
-    it('should deny access to a route if user permission is not defined for the route', function(done) {
+    it("should deny access to a route if user permission is not defined for the route", async () => {
       server.route({
-        method: 'DELETE',
-        path: '/foobar/{id}',
+        method: "DELETE",
+        path: "/foobar/{id}",
         config: {
-          handler: function(request, reply) {
-            reply('car deleted!');
+          handler: function(request, h) {
+            return "car deleted!";
           },
           plugins: {
             hapiRouteAcl: {
-              permissions: ['foobar:delete']
+              permissions: ["foobar:delete"]
             }
           }
         }
       });
-      server.inject({
-        method: 'DELETE',
-        url: '/foobar/1'
-      }, function(res) {
-        expect(res.statusCode).to.equal(401);
-        done();
+      let res = await server.inject({
+        method: "DELETE",
+        url: "/foobar/1"
       });
+      expect(res.statusCode).to.equal(401);
     });
 
-    it('should allow access to a route with multiple permission requirements if user has permissions', function(done) {
+    it("should allow access to a route with multiple permission requirements if user has permissions", async () => {
       server.route({
-        method: 'GET',
-        path: '/cars/{id}/drivers',
+        method: "GET",
+        path: "/cars/{id}/drivers",
         config: {
-          handler: function(request, reply) {
-            reply(['Greg', 'Tom', 'Sam']);
+          handler: function(request, h) {
+            return ["Greg", "Tom", "Sam"];
           },
           plugins: {
             hapiRouteAcl: {
-              permissions: ['cars:read', 'drivers:read']
+              permissions: ["cars:read", "drivers:read"]
             }
           }
         }
       });
-      server.inject({
-        method: 'GET',
-        url: '/cars/1/drivers'
-      }, function(res) {
-        expect(res.statusCode).to.equal(200);
-        done();
+      let res = await server.inject({
+        method: "GET",
+        url: "/cars/1/drivers"
       });
+      expect(res.statusCode).to.equal(200);
     });
 
-    it('should deny access to a route with two permission requirements if user does not have permissions', function(done) {
+    it("should deny access to a route with two permission requirements if user does not have permissions", async () => {
       server.route({
-        method: 'DELETE',
-        path: '/cars/{carId}/drivers/{driverId}',
+        method: "DELETE",
+        path: "/cars/{carId}/drivers/{driverId}",
         config: {
-          handler: function(request, reply) {
-            reply('driver deleted!');
+          handler: function(request, h) {
+            return "driver deleted!";
           },
           plugins: {
             hapiRouteAcl: {
-              permissions: ['drivers:delete', 'cars:read']
+              permissions: ["drivers:delete", "cars:read"]
             }
           }
         }
       });
-      server.inject({
-        method: 'DELETE',
-        url: '/cars/1/drivers/1'
-      }, function(res) {
-        expect(res.statusCode).to.equal(401);
-        done();
+      let res = await server.inject({
+        method: "DELETE",
+        url: "/cars/1/drivers/1"
       });
+      expect(res.statusCode).to.equal(401);
     });
 
-    it('should deny access to a route with multiple permission requirements if user does not have permissions', function(done) {
+    it("should deny access to a route with multiple permission requirements if user does not have permissions", async () => {
       server.route({
-        method: 'GET',
-        path: '/cars/{carId}/drivers/{driverId}/abilities/{abilitiesId}',
+        method: "GET",
+        path: "/cars/{carId}/drivers/{driverId}/abilities/{abilitiesId}",
         config: {
-          handler: function(request, reply) {
-            reply('driver deleted!');
+          handler: function(request, h) {
+            return "driver deleted!";
           },
           plugins: {
             hapiRouteAcl: {
-              permissions: ['drivers:read', 'cars:read', 'abilities:read']
+              permissions: ["drivers:read", "cars:read", "abilities:read"]
             }
           }
         }
       });
-      server.inject({
-        method: 'GET',
-        url: '/cars/1/drivers/1/abilities/1'
-      }, function(res) {
-        expect(res.statusCode).to.equal(401);
-        done();
+      let res = await server.inject({
+        method: "GET",
+        url: "/cars/1/drivers/1/abilities/1"
       });
+      expect(res.statusCode).to.equal(401);
     });
-
   });
-
 });


### PR DESCRIPTION
I can't figure out how this snippet works. request.domain... is undefined.

  ```
server.ext(
        "onPostAuth",
        function(request, reply) {
          request.domain.on("error", function(error) {
            request.caughtError = error;
          });
          return reply.continue;
        },
        { before: ["hapi-route-acl"] }
      );
```

```

Failed tests:
  8) hapi-route-acl route protection should throw an exception if route permission is not a string:
      Expected undefined to be an instance of Error
      at it (/home/travis/build/eventhough/hapi-route-acl/test/index.js:238:40
  9) hapi-route-acl route protection should throw an exception if route permission is not formatted properly:
      Expected undefined to be an instance of Error
      at it (/home/travis/build/eventhough/hapi-route-acl/test/index.js:277:40
```
  